### PR TITLE
Print value in dummy broker

### DIFF
--- a/eventbusk/brokers/dummy.py
+++ b/eventbusk/brokers/dummy.py
@@ -100,7 +100,7 @@ class Producer(BaseProducer):
         Only logs the message, does not deliver.
         """
         logger.info(
-            "Producing message {value=}.",
+            f"Producing message {value=}.",
             extra={
                 "topic": topic,
                 "value": value,

--- a/eventbusk/brokers/dummy.py
+++ b/eventbusk/brokers/dummy.py
@@ -100,7 +100,7 @@ class Producer(BaseProducer):
         Only logs the message, does not deliver.
         """
         logger.info(
-            "Producing message.",
+            "Producing message {value=}.",
             extra={
                 "topic": topic,
                 "value": value,


### PR DESCRIPTION
## Description

- During testing and local development, it's useful to print the message that is received for understanding and debugging.
- After making the change, the message will look like
```
[none] [49080] [INFO] [eventbusk.brokers.dummy] dummy.py:102
 Producing message value=b'{"event_date": "2022-02-23 17:15:43.658175",
 "ledger_entry_id": 18722, "company_id": 1, "company_name": "Acme Airbase", 
"integration_id": 195, "provider": "netsuite", "status": "created"}'.
```
- Without the change, the logger in development and CI env needs a change.