### PR TITLE
Switch kafka consumers from store_offset() to commit()

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,23 +39,39 @@ foo = Foo(foo=1)
 bus.send(foo)
 ```
 
-## Examples
-
-See `examples/eventbus.py` for a concrete example.
-You can run workers for all the receivers
-
-```bash
-eventbusk worker -A eventbus:bus
-```
-
 ## Contributing
 
-You can first setup the project locally as follows
+Pre-requisites include installing
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+
+You can start a Confluent Kafka server locally via docker by following
+https://docs.confluent.io/platform/current/platform-quickstart.html
+
+Next setup the project locally as follows
 
 ```bash
 git clone git@github.com:Airbase/eventbusk.git
 cd eventbusk
-poetry shell
-poetry install --no-root
 pre-commit install
+source $(poetry env info -p)/bin/activate
+poetry install --no-root
+pip install --editable .
+```
+
+Now you can run the example project consumers. Ensure the topics in the example are created first.
+
+```bash
+cd examples
+eventbusk worker -A eventbus:bus
+```
+
+
+You can also publish
+
+```bash
+python
+
+>>> from eventbus import bus, Fooey
+>>> bus.send(Fooey(foo_val="lorem ipsum"))
 ```

--- a/eventbusk/brokers/kafka.py
+++ b/eventbusk/brokers/kafka.py
@@ -156,7 +156,7 @@ class Consumer(BaseConsumer):
             {
                 "group.id": self.group,
                 "auto.offset.reset": "latest",  # TODO: This will change per receiver
-                "enable.auto.offset.store": False,
+                "enable.auto.commit": False,
             }
         )
         self._consumer = CConsumer(config)
@@ -190,9 +190,9 @@ class Consumer(BaseConsumer):
 
     def ack(self, message: Optional[MessageT]) -> None:
         """
-        Acknowledge the message
+        Acknowledge the message by explicitly committing.
         """
-        self._consumer.store_offsets(message=message)
+        self._consumer.commit(message=message)
 
 
 class Producer(BaseProducer):

--- a/examples/eventbus.py
+++ b/examples/eventbus.py
@@ -14,7 +14,14 @@ from dataclasses import dataclass
 
 from eventbusk import Event, EventBus
 
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
 logger = logging.getLogger(__name__)
+
+
 bus = EventBus(broker="kafka://localhost:9092")
 
 

--- a/tests/test_brokers.py
+++ b/tests/test_brokers.py
@@ -91,7 +91,6 @@ def test_consumer_factory_bad_broker(broker: str, topic: str, group: str) -> Non
     with pytest.raises(ValueError):
         # When Consumer is instantiated
         with Consumer(broker=broker, topic=topic, group=group) as consumer:
-
             assert consumer is not None
 
 
@@ -250,4 +249,4 @@ def test_kafka_consumer(
 
     # Then ensure underlying confluent consumer is correctly called
     cconsumer.poll.assert_called_once_with(timeout)
-    cconsumer.store_offsets.assert_called_once_with(message=msg)
+    cconsumer.commit.assert_called_once_with(message=msg)


### PR DESCRIPTION
## Changelog
- Switch kafka consumers from store_offset() to commit()


## Why?
>The stored offsets will be committed according to ‘auto.commit.interval.ms’ or manual offset-less `commit()`

store_offset() comes from Confluents own examples in the doc and is an optimization tradeoff. In prod we're seeing acks get lost because the worker hung in the middle after storing offset but before the auto commit happened. We're still trying to debug the original cause of why the workers hang. But meanwhile we want to move to a seemingly safer more explicit commit(), with stronger guarantees.

## Links
- [confluent-kafka commit()](https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html)
