### PR TITLE
Initialize producer class lazily on first send

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # eventbusk - Event Bus Framework
 
-- Version:
-- [Download](https://github.com/Airbase/eventbusk/)
-- [Source](https://github.com/Airbase/eventbusk/)
-- Keywords: event-bus, distributed, stream, processing, data, queue, kafka, python
+Keywords: event-bus, distributed, stream, processing, data, queue, kafka, python
 
 ## Install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "eventbusk"
-version = "0.1.3"
+version = "0.1.6"
 description = "Event bus with Kafka"
 authors = ["Airbase Inc <developers@airbase.io>"]
 


### PR DESCRIPTION
## Changelog
- Initialize producer class lazily on first send
  - Fix hanging flush() in celery forked processes 

## Links
- https://github.com/confluentinc/confluent-kafka-python/issues/1122 
 - https://github.com/dpkp/kafka-python/issues/1098
 - [Slack](https://airbase-team.slack.com/archives/CAW7FUQHY/p1702384967094999)