### PR TITLE
[JIRA#AC-7071] feat: add before_receive/after_receive hooks to EventBus

### DIFF
--- a/eventbusk/bus.py
+++ b/eventbusk/bus.py
@@ -51,7 +51,7 @@ ReceiverT = Callable[[Event], None]
 ReceiverWrappedT = Callable[[], None]
 ReceivedOuterT = Callable[[ReceiverT], ReceiverWrappedT]
 HookT = Callable[[], None]
-HooksT = HookT | list[HookT] | None
+HooksT = list[HookT] | None
 
 
 class EventBus:
@@ -86,8 +86,6 @@ class EventBus:
     def _to_hook_list(hooks: HooksT) -> list[HookT]:
         if hooks is None:
             return []
-        if callable(hooks):
-            return [hooks]
         return list(hooks)
 
     def __init__(

--- a/eventbusk/bus.py
+++ b/eventbusk/bus.py
@@ -1,6 +1,7 @@
 """
 EventBus implementation
 """
+
 from __future__ import annotations
 
 import json
@@ -49,6 +50,8 @@ EventT = type[Event]
 ReceiverT = Callable[[Event], None]
 ReceiverWrappedT = Callable[[], None]
 ReceivedOuterT = Callable[[ReceiverT], ReceiverWrappedT]
+HookT = Callable[[], None]
+HooksT = HookT | list[HookT] | None
 
 
 class EventBus:
@@ -79,8 +82,23 @@ class EventBus:
         ...
     """
 
-    def __init__(self, broker: str):
+    @staticmethod
+    def _to_hook_list(hooks: HooksT) -> list[HookT]:
+        if hooks is None:
+            return []
+        if callable(hooks):
+            return [hooks]
+        return list(hooks)
+
+    def __init__(
+        self,
+        broker: str,
+        before_receive: HooksT = None,
+        after_receive: HooksT = None,
+    ):
         self.broker = broker
+        self._before_receive_hooks: list[HookT] = self._to_hook_list(before_receive)
+        self._after_receive_hooks: list[HookT] = self._to_hook_list(after_receive)
         # Lazily create on first send
         # This is done to avoid issues forking, causing flush to fail.
         # https://github.com/confluentinc/confluent-kafka-python/issues/1122
@@ -96,6 +114,14 @@ class EventBus:
         self._topic_to_event: dict[str, str] = {}
         self._event_to_topic: dict[str, str] = {}
         self._receivers: set[ReceiverWrappedT] = set()
+
+    def add_before_receive_hook(self, hook: HookT) -> None:
+        """Register an additional hook to run before each event is processed."""
+        self._before_receive_hooks.append(hook)
+
+    def add_after_receive_hook(self, hook: HookT) -> None:
+        """Register an additional hook to run after each event is processed."""
+        self._after_receive_hooks.append(hook)
 
     @staticmethod
     def to_fqn(event_type: EventT | ReceiverT) -> str:
@@ -258,6 +284,16 @@ class EventBus:
                             event = event_type(**event_data)  # type: ignore
                             setattr(event, "event_id", event_id)
 
+                            for hook in self._before_receive_hooks:
+                                try:
+                                    hook()
+                                except Exception:  # pylint: disable=broad-except
+                                    logger.exception(
+                                        "Error in before_receive hook.",
+                                        extra=log_context,
+                                        exc_info=True,
+                                    )
+
                             try:
                                 func(event)
                                 success = True
@@ -271,6 +307,16 @@ class EventBus:
                                     exc_info=True,
                                 )
                                 success = False
+                            finally:
+                                for hook in self._after_receive_hooks:
+                                    try:
+                                        hook()
+                                    except Exception:  # pylint: disable=broad-except
+                                        logger.exception(
+                                            "Error in after_receive hook.",
+                                            extra=log_context,
+                                            exc_info=True,
+                                        )
 
                             if success:
                                 # TODO: Fix following

--- a/eventbusk/bus.py
+++ b/eventbusk/bus.py
@@ -113,14 +113,6 @@ class EventBus:
         self._event_to_topic: dict[str, str] = {}
         self._receivers: set[ReceiverWrappedT] = set()
 
-    def add_before_receive_hook(self, hook: HookT) -> None:
-        """Register an additional hook to run before each event is processed."""
-        self._before_receive_hooks.append(hook)
-
-    def add_after_receive_hook(self, hook: HookT) -> None:
-        """Register an additional hook to run after each event is processed."""
-        self._after_receive_hooks.append(hook)
-
     @staticmethod
     def to_fqn(event_type: EventT | ReceiverT) -> str:
         """

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -120,8 +120,8 @@ def test_bus_receive_hooks(mocker: MockerFixture) -> None:
 
     bus = EventBus(
         broker="kafka://localhost:9092",
-        before_receive=before_hook,
-        after_receive=after_hook,
+        before_receive=[before_hook],
+        after_receive=[after_hook],
     )
     bus.register_event("first_topic", Foo)
 

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -1,15 +1,15 @@
 """
 Test EventBus implementation
 """
+
 from __future__ import annotations
 
 import logging
 import uuid
 from dataclasses import dataclass
 
-from pytest_mock import MockerFixture
-
 from eventbusk import Event, EventBus
+from pytest_mock import MockerFixture
 
 logger = logging.getLogger(__name__)
 
@@ -109,3 +109,70 @@ def test_bus_receive() -> None:
     # Then ensure receivers are correctly registered
     assert foo_processor in bus.receivers
     assert bar_processor in bus.receivers
+
+
+def test_bus_receive_hooks(mocker: MockerFixture) -> None:
+    """
+    Test before_receive and after_receive hooks are stored correctly.
+    """
+    before_hook = mocker.Mock()
+    after_hook = mocker.Mock()
+
+    bus = EventBus(
+        broker="kafka://localhost:9092",
+        before_receive=before_hook,
+        after_receive=after_hook,
+    )
+    bus.register_event("first_topic", Foo)
+
+    @bus.receive(event_type=Foo)
+    def foo_processor(event: Event) -> None:
+        logger.info(event)
+
+    assert foo_processor in bus.receivers
+    assert bus._before_receive_hooks == [before_hook]
+    assert bus._after_receive_hooks == [after_hook]
+
+
+def test_bus_receive_hooks_as_list() -> None:
+    """
+    Test that hooks can be passed as a list.
+    """
+    hook1 = lambda: None  # noqa: E731
+    hook2 = lambda: None  # noqa: E731
+
+    bus = EventBus(
+        broker="kafka://localhost:9092",
+        before_receive=[hook1, hook2],
+        after_receive=[hook1],
+    )
+
+    assert bus._before_receive_hooks == [hook1, hook2]
+    assert bus._after_receive_hooks == [hook1]
+
+
+def test_bus_add_hooks() -> None:
+    """
+    Test add_before_receive_hook and add_after_receive_hook methods.
+    """
+    hook1 = lambda: None  # noqa: E731
+    hook2 = lambda: None  # noqa: E731
+
+    bus = EventBus(broker="kafka://localhost:9092")
+    assert bus._before_receive_hooks == []
+    assert bus._after_receive_hooks == []
+
+    bus.add_before_receive_hook(hook1)
+    bus.add_after_receive_hook(hook2)
+
+    assert bus._before_receive_hooks == [hook1]
+    assert bus._after_receive_hooks == [hook2]
+
+
+def test_bus_receive_no_hooks() -> None:
+    """
+    Test that hooks default to empty lists when not provided.
+    """
+    bus = EventBus(broker="kafka://localhost:9092")
+    assert bus._before_receive_hooks == []
+    assert bus._after_receive_hooks == []

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -10,8 +10,9 @@ import uuid
 from dataclasses import dataclass
 from unittest.mock import MagicMock
 
-from eventbusk import Event, EventBus
 from pytest_mock import MockerFixture
+
+from eventbusk import Event, EventBus
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ class Bar(Event):
 BROKER = "kafka://localhost:9092"
 
 
-def _make_mock_consumer(event_data: dict) -> MagicMock:
+def _make_mock_consumer(event_data: dict) -> tuple[MagicMock, MagicMock]:
     """
     Create a mock Consumer that yields one message with the given event data,
     then raises KeyboardInterrupt to exit the receive loop.

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -4,9 +4,11 @@ Test EventBus implementation
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from dataclasses import dataclass
+from unittest.mock import MagicMock
 
 from eventbusk import Event, EventBus
 from pytest_mock import MockerFixture
@@ -32,6 +34,25 @@ class Bar(Event):
     second: int
 
 
+BROKER = "kafka://localhost:9092"
+
+
+def _make_mock_consumer(event_data: dict) -> MagicMock:
+    """
+    Create a mock Consumer that yields one message with the given event data,
+    then raises KeyboardInterrupt to exit the receive loop.
+    """
+    message = MagicMock()
+    message.error.return_value = None
+    message.value.return_value = json.dumps(event_data).encode("utf-8")
+
+    consumer = MagicMock()
+    consumer.poll.side_effect = [message, KeyboardInterrupt]
+    consumer.__enter__ = MagicMock(return_value=consumer)
+    consumer.__exit__ = MagicMock(return_value=False)
+    return consumer, message
+
+
 def test_bus_send(mocker: MockerFixture) -> None:
     """
     Test basic producer
@@ -39,7 +60,7 @@ def test_bus_send(mocker: MockerFixture) -> None:
     # Given an instance of an event bus
     producer = mocker.Mock()
     mocker.patch("eventbusk.bus.Producer", return_value=producer)
-    bus = EventBus(broker="kafka://localhost:9092")
+    bus = EventBus(broker=BROKER)
 
     # Given events registered to certain topics
     bus.register_event(topic="first_topic", event_type=Foo)
@@ -91,7 +112,7 @@ def test_bus_receive() -> None:
     Test basic consumer
     """
     # Given an instance of an event bus
-    bus = EventBus(broker="kafka://localhost:9092")
+    bus = EventBus(broker=BROKER)
 
     # Given events registered to certain topics
     bus.register_event("first_topic", Foo)
@@ -111,38 +132,20 @@ def test_bus_receive() -> None:
     assert bar_processor in bus.receivers
 
 
-def test_bus_receive_hooks(mocker: MockerFixture) -> None:
-    """
-    Test before_receive and after_receive hooks are stored correctly.
-    """
-    before_hook = mocker.Mock()
-    after_hook = mocker.Mock()
+def test_hooks_default_to_empty_lists() -> None:
+    """Hooks should default to empty lists when not provided."""
+    bus = EventBus(broker=BROKER)
+    assert bus._before_receive_hooks == []
+    assert bus._after_receive_hooks == []
+
+
+def test_hooks_stored_from_init() -> None:
+    """Hooks passed at init should be stored as lists."""
+    hook1 = MagicMock()
+    hook2 = MagicMock()
 
     bus = EventBus(
-        broker="kafka://localhost:9092",
-        before_receive=[before_hook],
-        after_receive=[after_hook],
-    )
-    bus.register_event("first_topic", Foo)
-
-    @bus.receive(event_type=Foo)
-    def foo_processor(event: Event) -> None:
-        logger.info(event)
-
-    assert foo_processor in bus.receivers
-    assert bus._before_receive_hooks == [before_hook]
-    assert bus._after_receive_hooks == [after_hook]
-
-
-def test_bus_receive_hooks_as_list() -> None:
-    """
-    Test that hooks can be passed as a list.
-    """
-    hook1 = lambda: None  # noqa: E731
-    hook2 = lambda: None  # noqa: E731
-
-    bus = EventBus(
-        broker="kafka://localhost:9092",
+        broker=BROKER,
         before_receive=[hook1, hook2],
         after_receive=[hook1],
     )
@@ -151,28 +154,54 @@ def test_bus_receive_hooks_as_list() -> None:
     assert bus._after_receive_hooks == [hook1]
 
 
-def test_bus_add_hooks() -> None:
-    """
-    Test add_before_receive_hook and add_after_receive_hook methods.
-    """
-    hook1 = lambda: None  # noqa: E731
-    hook2 = lambda: None  # noqa: E731
+def test_hooks_execute_in_order_around_handler(mocker: MockerFixture) -> None:
+    """before_receive hooks run before the handler, after_receive hooks run after."""
+    manager = mocker.Mock()
+    bus = EventBus(
+        broker=BROKER,
+        before_receive=[manager.before_hook],
+        after_receive=[manager.after_hook],
+    )
+    bus.register_event("first_topic", Foo)
 
-    bus = EventBus(broker="kafka://localhost:9092")
-    assert bus._before_receive_hooks == []
-    assert bus._after_receive_hooks == []
+    @bus.receive(event_type=Foo)
+    def foo_processor(event: Event) -> None:
+        manager.handler(event)
 
-    bus.add_before_receive_hook(hook1)
-    bus.add_after_receive_hook(hook2)
+    consumer, message = _make_mock_consumer({"first": 42})
+    mocker.patch("eventbusk.bus.Consumer", return_value=consumer)
 
-    assert bus._before_receive_hooks == [hook1]
-    assert bus._after_receive_hooks == [hook2]
+    foo_processor()
+
+    assert manager.mock_calls == [
+        mocker.call.before_hook(),
+        mocker.call.handler(mocker.ANY),
+        mocker.call.after_hook(),
+    ]
+    consumer.ack.assert_called_once_with(message=message)
 
 
-def test_bus_receive_no_hooks() -> None:
-    """
-    Test that hooks default to empty lists when not provided.
-    """
-    bus = EventBus(broker="kafka://localhost:9092")
-    assert bus._before_receive_hooks == []
-    assert bus._after_receive_hooks == []
+def test_after_hooks_run_when_handler_raises(mocker: MockerFixture) -> None:
+    """after_receive hooks run even when the handler raises; message is not acked."""
+    before_hook = mocker.Mock()
+    after_hook = mocker.Mock()
+
+    bus = EventBus(
+        broker=BROKER,
+        before_receive=[before_hook],
+        after_receive=[after_hook],
+    )
+    bus.register_event("first_topic", Foo)
+
+    @bus.receive(event_type=Foo)
+    def foo_processor(event: Event) -> None:
+        raise ValueError("handler error")
+
+    consumer, _ = _make_mock_consumer({"first": 42})
+    mocker.patch("eventbusk.bus.Consumer", return_value=consumer)
+
+    foo_processor()
+
+    before_hook.assert_called_once()
+    after_hook.assert_called_once()
+    consumer.ack.assert_not_called()


### PR DESCRIPTION
Eventbusk runs each receiver in a long-lived while-True poll loop. Between events, PostgreSQL (or connection poolers like PgBouncer) can close idle database connections. When the next event arrives, the application tries to use the now-dead connection and gets:

    psycopg.OperationalError: the connection is closed

To fix this generically, add optional `before_receive` and `after_receive` hooks to `EventBus.__init__`. These are called in the receiver poll loop around `func(event)`, with `after_receive` in a `finally` block so it always runs even when the handler raises.

**Hook type:** `HooksT = list[Callable[[], None]] | None`

Usage (Django):

```python
from django.db import close_old_connections

bus = EventBus(
    broker_url,
    before_receive=[close_old_connections],
    after_receive=[close_old_connections],
)
```

**Key behaviors:**
- Each hook runs in its own try/except — a failing hook does not affect other hooks or the ack/nack decision
- `after_receive` hooks run in a `finally` block, so they execute even when the handler raises
- Hooks default to empty lists when not provided