### PR TITLE
Fix pylint, enforce keyword-only args, consolidate linting to ruff, deprecate flake8/isort/autoflake

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-format = pylint
-max-line-length = 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,11 +29,6 @@ repos:
     -   id: autoflake
         args: [--in-place, --remove-all-unused-import]
 
--   repo: https://github.com/pycqa/flake8
-    rev: 7.3.0
-    hooks:
-    -   id: flake8
-
 -   repo: https://github.com/pycqa/pylint
     rev: v4.0.5
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,15 +36,6 @@ repos:
         args: [--extension-pkg-whitelist=confluent_kafka, --load-plugins=pylint.extensions.bad_builtin, --load-plugins=pylint.extensions.mccabe]
         additional_dependencies: ["click", "confluent_kafka", "cotyledon", "pytest", "pytest_mock"]
 
--   repo: https://github.com/pycqa/isort
-    rev: 8.0.1
-    hooks:
-      - id: isort
-        name: isort (python)
-      - id: isort
-        name: isort (pyi)
-        types: [pyi]
-
 
 # -   repo: https://github.com/pre-commit/mirrors-mypy
 #     rev: v0.902

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,12 +23,6 @@ repos:
         args: [ --fix ]
     -   id: ruff-format
 
--   repo: https://github.com/PyCQA/autoflake
-    rev: v2.3.3
-    hooks:
-    -   id: autoflake
-        args: [--in-place, --remove-all-unused-import]
-
 -   repo: https://github.com/pycqa/pylint
     rev: v4.0.5
     hooks:

--- a/README.md
+++ b/README.md
@@ -38,36 +38,52 @@ bus.send(foo)
 
 ## Contributing
 
-Pre-requisites include installing
+Pre-requisites:
 
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 
-You can start a Confluent Kafka server locally via docker by following
+You can start a Confluent Kafka server locally via Docker by following
 https://docs.confluent.io/platform/current/platform-quickstart.html
 
-Next setup the project locally as follows
+Set up the project locally:
 
 ```bash
 git clone git@github.com:Airbase/eventbusk.git
 cd eventbusk
+uv sync --extra dev
 pre-commit install
-source $(poetry env info -p)/bin/activate
-poetry install --no-root
-pip install --editable .
+```
+
+Run the tests:
+
+```bash
+uv run task test
+```
+
+Run the linter:
+
+```bash
+uv run task pylint
+```
+
+Format the code:
+
+```bash
+uv run task format
 ```
 
 Now you can run the example project consumers. Ensure the topics in the example are created first.
 
 ```bash
 cd examples
-eventbusk worker -A eventbus:bus
+uv run eventbusk worker -A eventbus:bus
 ```
 
-
-You can also publish
+You can also publish:
 
 ```bash
-python
+uv run python
 
 >>> from eventbus import bus, Fooey
 >>> bus.send(Fooey(foo_val="lorem ipsum"))

--- a/eventbusk/brokers/__init__.py
+++ b/eventbusk/brokers/__init__.py
@@ -7,10 +7,8 @@ from __future__ import annotations
 import logging
 
 from .base import BaseConsumer, BaseProducer, DeliveryCallBackT
-from .dummy import Consumer as DummyConsumer
-from .dummy import Producer as DummyProducer
-from .kafka import Consumer as KafkaConsumer
-from .kafka import Producer as KafkaProducer
+from .dummy import Consumer as DummyConsumer, Producer as DummyProducer
+from .kafka import Consumer as KafkaConsumer, Producer as KafkaProducer
 
 logger = logging.getLogger(__name__)
 

--- a/eventbusk/brokers/__init__.py
+++ b/eventbusk/brokers/__init__.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 import logging
 
 from .base import BaseConsumer, BaseProducer, DeliveryCallBackT
-from .dummy import Consumer as DummyConsumer, Producer as DummyProducer
-from .kafka import Consumer as KafkaConsumer, Producer as KafkaProducer
+from .dummy import Consumer as DummyConsumer
+from .dummy import Producer as DummyProducer
+from .kafka import Consumer as KafkaConsumer
+from .kafka import Producer as KafkaProducer
 
 logger = logging.getLogger(__name__)
 

--- a/eventbusk/brokers/__init__.py
+++ b/eventbusk/brokers/__init__.py
@@ -27,7 +27,7 @@ def consumer_factory(broker: str, topic: str, group: str) -> BaseConsumer:
     raise ValueError("Unsupported broker.")
 
 
-Consumer = consumer_factory
+Consumer = consumer_factory  # pylint: disable=invalid-name
 
 
 def producer_factory(broker: str) -> BaseProducer:
@@ -41,4 +41,4 @@ def producer_factory(broker: str) -> BaseProducer:
     raise ValueError("Unsupported broker.")
 
 
-Producer = producer_factory
+Producer = producer_factory  # pylint: disable=invalid-name

--- a/eventbusk/brokers/base.py
+++ b/eventbusk/brokers/base.py
@@ -98,7 +98,7 @@ class BaseProducer(ABC):
         super().__init__()
 
     @abstractmethod
-    def produce(  # type: ignore # pylint: disable=too-many-arguments
+    def produce(  # type: ignore # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         topic: str,
         value: MessageT,

--- a/eventbusk/brokers/base.py
+++ b/eventbusk/brokers/base.py
@@ -98,10 +98,11 @@ class BaseProducer(ABC):
         super().__init__()
 
     @abstractmethod
-    def produce(  # type: ignore # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def produce(  # type: ignore # pylint: disable=too-many-arguments
         self,
         topic: str,
         value: MessageT,
+        *,
         flush: bool = True,
         on_delivery: DeliveryCallBackT = None,
         fail_silently: bool = False,

--- a/eventbusk/brokers/base.py
+++ b/eventbusk/brokers/base.py
@@ -64,7 +64,7 @@ class BaseConsumer(ContextDecorator, ABC):
     def __enter__(self) -> BaseConsumer:
         return self
 
-    def __exit__(
+    def __exit__(  # pylint: disable=too-many-positional-arguments
         self,
         exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
@@ -98,7 +98,7 @@ class BaseProducer(ABC):
         super().__init__()
 
     @abstractmethod
-    def produce(  # type: ignore # pylint: disable=too-many-arguments
+    def produce(  # type: ignore
         self,
         topic: str,
         value: MessageT,

--- a/eventbusk/brokers/dummy.py
+++ b/eventbusk/brokers/dummy.py
@@ -89,10 +89,11 @@ class Producer(BaseProducer):
         super().__init__(broker)
         self.broker = BrokerURI.from_uri(broker)
 
-    def produce(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def produce(  # pylint: disable=too-many-arguments
         self,
         topic: str,
         value: MessageT,
+        *,
         flush: bool = True,
         on_delivery: DeliveryCallBackT = None,
         fail_silently: bool = False,

--- a/eventbusk/brokers/dummy.py
+++ b/eventbusk/brokers/dummy.py
@@ -62,7 +62,7 @@ class Consumer(BaseConsumer):
 
     broker: BrokerURI
 
-    def __init__(self, broker: str, topic: str, group: str) -> None:
+    def __init__(self, broker: str, *, topic: str, group: str) -> None:
         super().__init__()
         self.broker = BrokerURI.from_uri(broker)
         self.topic = topic
@@ -89,7 +89,7 @@ class Producer(BaseProducer):
         super().__init__(broker)
         self.broker = BrokerURI.from_uri(broker)
 
-    def produce(  # pylint: disable=too-many-arguments
+    def produce(
         self,
         topic: str,
         value: MessageT,

--- a/eventbusk/brokers/dummy.py
+++ b/eventbusk/brokers/dummy.py
@@ -89,7 +89,7 @@ class Producer(BaseProducer):
         super().__init__(broker)
         self.broker = BrokerURI.from_uri(broker)
 
-    def produce(  # pylint: disable=too-many-arguments
+    def produce(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         topic: str,
         value: MessageT,

--- a/eventbusk/brokers/kafka.py
+++ b/eventbusk/brokers/kafka.py
@@ -11,11 +11,7 @@ from typing import TYPE_CHECKING, Union
 
 from confluent_kafka import (  # type: ignore
     Consumer as CConsumer,
-)
-from confluent_kafka import (
     KafkaError,
-)
-from confluent_kafka import (
     Producer as CProducer,
 )
 

--- a/eventbusk/brokers/kafka.py
+++ b/eventbusk/brokers/kafka.py
@@ -136,7 +136,7 @@ class Consumer(BaseConsumer):
 
     broker: BrokerURI
 
-    def __init__(self, broker: str, topic: str, group: str):
+    def __init__(self, broker: str, *, topic: str, group: str):
         super().__init__()
         self.broker = BrokerURI.from_uri(broker)
         self.topic = topic
@@ -164,7 +164,7 @@ class Consumer(BaseConsumer):
         self._consumer.subscribe([self.topic])
         return self
 
-    def __exit__(
+    def __exit__(  # pylint: disable=too-many-positional-arguments
         self,
         exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
@@ -207,7 +207,7 @@ class Producer(BaseProducer):
         config = self.broker.default_config
         self._producer = CProducer(config)
 
-    def produce(  # pylint: disable=too-many-arguments
+    def produce(
         self,
         topic: str,
         value: MessageT,

--- a/eventbusk/brokers/kafka.py
+++ b/eventbusk/brokers/kafka.py
@@ -11,7 +11,11 @@ from typing import TYPE_CHECKING, Union
 
 from confluent_kafka import (  # type: ignore
     Consumer as CConsumer,
+)
+from confluent_kafka import (
     KafkaError,
+)
+from confluent_kafka import (
     Producer as CProducer,
 )
 

--- a/eventbusk/brokers/kafka.py
+++ b/eventbusk/brokers/kafka.py
@@ -207,7 +207,7 @@ class Producer(BaseProducer):
         config = self.broker.default_config
         self._producer = CProducer(config)
 
-    def produce(  # pylint: disable=too-many-arguments
+    def produce(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         topic: str,
         value: MessageT,
@@ -231,7 +231,7 @@ class Producer(BaseProducer):
             self._producer.produce(topic=topic, value=value, on_delivery=on_delivery)
             if flush:
                 self._producer.flush()
-        except KafkaError as exc:
+        except KafkaError as exc:  # pylint: disable=catching-non-exception
             if fail_silently:
                 logger.warning(
                     "Error producing event.",
@@ -241,4 +241,4 @@ class Producer(BaseProducer):
                     #    attribute '__traceback__'
                 )
             else:
-                raise ProducerError from exc
+                raise ProducerError from exc  # pylint: disable=bad-exception-cause

--- a/eventbusk/brokers/kafka.py
+++ b/eventbusk/brokers/kafka.py
@@ -207,10 +207,11 @@ class Producer(BaseProducer):
         config = self.broker.default_config
         self._producer = CProducer(config)
 
-    def produce(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def produce(  # pylint: disable=too-many-arguments
         self,
         topic: str,
         value: MessageT,
+        *,
         flush: bool = True,
         on_delivery: DeliveryCallBackT = None,
         fail_silently: bool = False,

--- a/eventbusk/bus.py
+++ b/eventbusk/bus.py
@@ -51,7 +51,7 @@ ReceiverT = Callable[[Event], None]
 ReceiverWrappedT = Callable[[], None]
 ReceivedOuterT = Callable[[ReceiverT], ReceiverWrappedT]
 HookT = Callable[[], None]
-HooksT = list[HookT] | None
+HooksT = list[HookT] | None  # pylint: disable=invalid-name
 
 
 class EventBus:
@@ -210,7 +210,7 @@ class EventBus:
             }
 
             @wraps(func)
-            def wrapper() -> None:
+            def wrapper() -> None:  # pylint: disable=too-many-branches
                 with Consumer(broker=self.broker, topic=topic, group=group) as consumer:
                     # TODO: Max-number-of-tasks
                     while True:

--- a/eventbusk/bus.py
+++ b/eventbusk/bus.py
@@ -91,6 +91,7 @@ class EventBus:
     def __init__(
         self,
         broker: str,
+        *,
         before_receive: HooksT = None,
         after_receive: HooksT = None,
     ):
@@ -140,6 +141,7 @@ class EventBus:
     def send(
         self,
         event: Event,
+        *,
         on_delivery: DeliveryCallBackT = None,
         flush: bool = True,
         fail_silently: bool = False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pre-commit==4.6.0",
+    "pylint>=4.0",
+    "ruff>=0.9",
     "pytest==9.0.3",
     "pytest-cov==7.1.0",
     "pytest-mock==3.15.1",
@@ -154,6 +156,9 @@ directory = "htmlcov"
 output = "coverage.xml"
 
 [tool.taskipy.tasks]
+pylint = "pylint --extension-pkg-whitelist=confluent_kafka --load-plugins=pylint.extensions.bad_builtin --load-plugins=pylint.extensions.mccabe eventbusk tests"
+ruff = "ruff check"
+format = "ruff format"
 test = "pytest --cov=. --cov-config=pyproject.toml --no-cov-on-fail"
 coverage = "coverage report --rcfile=pyproject.toml"
 coverage_report = "coverage report --rcfile=pyproject.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ src_paths = ["eventbusk"]
 line-length = 88
 target-version = "py313"
 
+[tool.ruff.lint]
+extend-select = ["E501"]
+
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ warn_unused_ignores = true
 bad-functions = ["print"]
 jobs = 1
 max-complexity = 10
-suggestion-mode = "yes"
 
 [tool.pylint.format]
 max-line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,24 +30,18 @@ dev = [
 [project.scripts]
 eventbusk = "eventbusk.cli:cli"
 
-[tool.isort]
-combine_as_imports = true
-profile = "black"
-src_paths = ["eventbusk"]
-
 [tool.ruff]
 line-length = 88
 target-version = "py313"
 
 [tool.ruff.lint]
-extend-select = ["E501"]
+extend-select = ["E501", "I"]
 
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
-
 
 [tool.mypy]
 python_version = "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ target-version = "py313"
 [tool.ruff.lint]
 extend-select = ["E501", "I"]
 
+[tool.ruff.lint.isort]
+combine-as-imports = true
+
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,8 @@ single-line-class-stmt = "no"
 single-line-if-stmt = "no"
 
 [tool.pylint.design]
-max-args = 5
+max-args = 6
+max-positional-arguments = 3
 max-attributes = 7
 max-bool-expr = 5
 max-branches = 15

--- a/tests/test_brokers.py
+++ b/tests/test_brokers.py
@@ -13,12 +13,20 @@ from pytest_mock import MockerFixture
 from eventbusk.brokers import Consumer, Producer
 from eventbusk.brokers.dummy import (
     BrokerURI as DummyBrokerURI,
+)
+from eventbusk.brokers.dummy import (
     Consumer as DummyConsumer,
+)
+from eventbusk.brokers.dummy import (
     Producer as DummyProducer,
 )
 from eventbusk.brokers.kafka import (
     BrokerURI as KafkaBrokerURI,
+)
+from eventbusk.brokers.kafka import (
     Consumer as KafkaConsumer,
+)
+from eventbusk.brokers.kafka import (
     Producer as KafkaProducer,
 )
 from eventbusk.exceptions import ProducerError

--- a/tests/test_brokers.py
+++ b/tests/test_brokers.py
@@ -13,20 +13,12 @@ from pytest_mock import MockerFixture
 from eventbusk.brokers import Consumer, Producer
 from eventbusk.brokers.dummy import (
     BrokerURI as DummyBrokerURI,
-)
-from eventbusk.brokers.dummy import (
     Consumer as DummyConsumer,
-)
-from eventbusk.brokers.dummy import (
     Producer as DummyProducer,
 )
 from eventbusk.brokers.kafka import (
     BrokerURI as KafkaBrokerURI,
-)
-from eventbusk.brokers.kafka import (
     Consumer as KafkaConsumer,
-)
-from eventbusk.brokers.kafka import (
     Producer as KafkaProducer,
 )
 from eventbusk.exceptions import ProducerError

--- a/tests/test_brokers.py
+++ b/tests/test_brokers.py
@@ -212,7 +212,7 @@ def test_kafka_producer_error(
     cproducer = mocker.Mock()
 
     def raise_exc(*args: Any, **kwargs: Any) -> None:
-        raise KafkaError(KafkaError.BROKER_NOT_AVAILABLE)
+        raise KafkaError(KafkaError.BROKER_NOT_AVAILABLE)  # pylint: disable=raising-non-exception
 
     cproducer.produce.side_effect = raise_exc
     mocker.patch("eventbusk.brokers.kafka.CProducer", return_value=cproducer)

--- a/tests/test_brokers.py
+++ b/tests/test_brokers.py
@@ -212,7 +212,9 @@ def test_kafka_producer_error(
     cproducer = mocker.Mock()
 
     def raise_exc(*args: Any, **kwargs: Any) -> None:
-        raise KafkaError(KafkaError.BROKER_NOT_AVAILABLE)  # pylint: disable=raising-non-exception
+        raise KafkaError(  # pylint: disable=raising-non-exception
+            KafkaError.BROKER_NOT_AVAILABLE
+        )
 
     cproducer.produce.side_effect = raise_exc
     mocker.patch("eventbusk.brokers.kafka.CProducer", return_value=cproducer)

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -151,8 +151,10 @@ def test_hooks_stored_from_init() -> None:
         after_receive=[hook1],
     )
 
-    assert bus._before_receive_hooks == [hook1, hook2]  # pylint: disable=protected-access
-    assert bus._after_receive_hooks == [hook1]  # pylint: disable=protected-access
+    before = bus._before_receive_hooks  # pylint: disable=protected-access
+    after = bus._after_receive_hooks  # pylint: disable=protected-access
+    assert before == [hook1, hook2]
+    assert after == [hook1]
 
 
 def test_hooks_execute_in_order_around_handler(mocker: MockerFixture) -> None:

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -81,8 +81,8 @@ def test_bus_send(mocker: MockerFixture) -> None:
         """
         logger.info(error, event)
 
-    bus.send(foo_event, on_delivery)
-    bus.send(bar_event, on_delivery)
+    bus.send(foo_event, on_delivery=on_delivery)
+    bus.send(bar_event, on_delivery=on_delivery)
 
     # Then check the underlying producer was correctly called with the right event json
     assert bus is not None

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -136,8 +136,8 @@ def test_bus_receive() -> None:
 def test_hooks_default_to_empty_lists() -> None:
     """Hooks should default to empty lists when not provided."""
     bus = EventBus(broker=BROKER)
-    assert bus._before_receive_hooks == []
-    assert bus._after_receive_hooks == []
+    assert not bus._before_receive_hooks  # pylint: disable=protected-access
+    assert not bus._after_receive_hooks  # pylint: disable=protected-access
 
 
 def test_hooks_stored_from_init() -> None:
@@ -151,8 +151,8 @@ def test_hooks_stored_from_init() -> None:
         after_receive=[hook1],
     )
 
-    assert bus._before_receive_hooks == [hook1, hook2]
-    assert bus._after_receive_hooks == [hook1]
+    assert bus._before_receive_hooks == [hook1, hook2]  # pylint: disable=protected-access
+    assert bus._after_receive_hooks == [hook1]  # pylint: disable=protected-access
 
 
 def test_hooks_execute_in_order_around_handler(mocker: MockerFixture) -> None:
@@ -172,7 +172,7 @@ def test_hooks_execute_in_order_around_handler(mocker: MockerFixture) -> None:
     consumer, message = _make_mock_consumer({"first": 42})
     mocker.patch("eventbusk.bus.Consumer", return_value=consumer)
 
-    foo_processor()
+    foo_processor()  # pylint: disable=no-value-for-parameter
 
     assert manager.mock_calls == [
         mocker.call.before_hook(),
@@ -201,7 +201,7 @@ def test_after_hooks_run_when_handler_raises(mocker: MockerFixture) -> None:
     consumer, _ = _make_mock_consumer({"first": 42})
     mocker.patch("eventbusk.bus.Consumer", return_value=consumer)
 
-    foo_processor()
+    foo_processor()  # pylint: disable=no-value-for-parameter
 
     before_hook.assert_called_once()
     after_hook.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
+name = "astroid"
+version = "4.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -133,6 +142,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -154,11 +172,13 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pylint" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-socket" },
     { name = "pytest-xdist" },
+    { name = "ruff" },
     { name = "taskipy" },
 ]
 
@@ -168,11 +188,13 @@ requires-dist = [
     { name = "confluent-kafka", specifier = ">=2.3.0" },
     { name = "cotyledon", specifier = ">=1.7" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.6.0" },
+    { name = "pylint", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = "==3.15.1" },
     { name = "pytest-socket", marker = "extra == 'dev'", specifier = "==0.7.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.8.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
     { name = "taskipy", marker = "extra == 'dev'", specifier = ">=1.14" },
 ]
 provides-extras = ["dev"]
@@ -211,6 +233,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -296,6 +336,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pylint"
+version = "4.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "dill" },
+    { name = "isort" },
+    { name = "mccabe" },
+    { name = "platformdirs" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
 ]
 
 [[package]]
@@ -415,6 +473,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798, upload-time = "2026-05-14T13:44:06.427Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761, upload-time = "2026-05-14T13:44:04.375Z" },
+    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451, upload-time = "2026-05-14T13:44:25.221Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285, upload-time = "2026-05-14T13:44:08.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063, upload-time = "2026-05-14T13:44:11.274Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079, upload-time = "2026-05-14T13:44:01.634Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833, upload-time = "2026-05-14T13:43:59.043Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486, upload-time = "2026-05-14T13:44:27.761Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189, upload-time = "2026-05-14T13:44:13.704Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380, upload-time = "2026-05-14T13:43:56.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605, upload-time = "2026-05-14T13:44:20.748Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554, upload-time = "2026-05-14T13:44:16.256Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133, upload-time = "2026-05-14T13:44:22.808Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
+]
+
+[[package]]
 name = "setproctitle"
 version = "1.3.7"
 source = { registry = "https://pypi.org/simple" }
@@ -503,6 +586,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Fix all pylint errors (rated 10.00/10)
- Remove flake8 — fully covered by ruff (E501 enabled via `extend-select`)
- Remove isort — replaced by ruff's built-in import sorting (`I` rules)
- Enforce keyword-only arguments on `produce()`, `send()`, and `__init__()` using `*`
- Set `max-positional-arguments = 3`, `max-args = 6` in pylint config
- Add `pylint` and `ruff` to dev dependencies so they work via `uv run` without pre-commit
- Add taskipy tasks: `task pylint`, `task ruff`, `task format`
- Update contributing docs to use `uv` instead of `poetry`

## Changes

### Pylint fixes
- Remove invalid `suggestion-mode` option from `[tool.pylint.master]`
- Add `invalid-name` disables for `Consumer`/`Producer` factory aliases and `HooksT` type alias
- Add `catching-non-exception` / `bad-exception-cause` disables for `KafkaError` (C extension, not a Python `Exception`)
- Add `too-many-branches` disable on inner `wrapper()` in `bus.receive`
- Fix test assertions: `== []` to `not` (C1803), add `protected-access` and `no-value-for-argument` disables

### Keyword-only arguments
- Add `*` to `produce()` on all brokers — `flush`, `on_delivery`, `fail_silently` are now keyword-only
- Add `*` to `EventBus.send()` — `on_delivery`, `flush`, `fail_silently` are now keyword-only
- Add `*` to `EventBus.__init__()` — `before_receive`, `after_receive` are now keyword-only
- Add `*` to `Consumer.__init__()` (kafka + dummy) — `topic`, `group` are now keyword-only
- Add `too-many-positional-arguments` disable on `__exit__` dunder methods (called positionally by Python)
- Set `max-positional-arguments = 3`, `max-args = 6` in pylint design config

### Linting consolidation
- Remove flake8 hook from `.pre-commit-config.yaml` and delete `.flake8`
- Remove isort hook from `.pre-commit-config.yaml` and delete `[tool.isort]` config
- Add `[tool.ruff.lint] extend-select = ["E501", "I"]` so ruff enforces line length and import sorting
- `pylint>=4.0` and `ruff>=0.9` added to `[project.optional-dependencies] dev`
- New taskipy tasks: `task pylint`, `task ruff` (`ruff check`), `task format` (`ruff format`)

### Docs
- Replace `poetry` setup steps with `uv sync --extra dev`
- Add `uv run task test`, `uv run task pylint`, `uv run task format` sections
- Prefix example commands with `uv run`

## Test Plan
- [x] 27 tests pass (`uv run task test`)
- [x] `uv run task pylint` → 10.00/10
- [x] `uv run task ruff` → All checks passed
- [x] `uv run task format` → All files unchanged
- [x] `pre-commit run --all-files` → All hooks passed