### PR TITLE
chore: enable all ruff checks (select=ALL) with sensible ignores

### DIFF
--- a/eventbusk/__init__.py
+++ b/eventbusk/__init__.py
@@ -1,9 +1,7 @@
-"""
-Event Bus Framework
-"""
+"""Event Bus Framework."""
 
 from __future__ import annotations
 
 from .bus import Event, EventBus
 
-__all__ = ["EventBus", "Event"]
+__all__ = ["Event", "EventBus"]

--- a/eventbusk/brokers/__init__.py
+++ b/eventbusk/brokers/__init__.py
@@ -15,7 +15,7 @@ __all__ = ["Consumer", "DeliveryCallBackT", "Producer"]
 
 
 def consumer_factory(broker: str, topic: str, group: str) -> BaseConsumer:
-    """Return a consumer instance for the specied broker url."""
+    """Return a consumer instance for the specified broker url."""
     if broker.startswith("kafka"):
         return KafkaConsumer(broker=broker, topic=topic, group=group)
     if broker.startswith("dummy"):
@@ -27,7 +27,7 @@ Consumer = consumer_factory  # pylint: disable=invalid-name
 
 
 def producer_factory(broker: str) -> BaseProducer:
-    """Return a producer instance for the specied broker url."""
+    """Return a producer instance for the specified broker url."""
     if broker.startswith("kafka"):
         return KafkaProducer(broker)
     if broker.startswith("dummy"):

--- a/eventbusk/brokers/__init__.py
+++ b/eventbusk/brokers/__init__.py
@@ -1,6 +1,4 @@
-"""
-Generic interface for brokers
-"""
+"""Generic interface for brokers."""
 
 from __future__ import annotations
 
@@ -13,13 +11,11 @@ from .kafka import Consumer as KafkaConsumer, Producer as KafkaProducer
 logger = logging.getLogger(__name__)
 
 
-__all__ = ["Consumer", "Producer", "DeliveryCallBackT"]
+__all__ = ["Consumer", "DeliveryCallBackT", "Producer"]
 
 
 def consumer_factory(broker: str, topic: str, group: str) -> BaseConsumer:
-    """
-    Return a consumer instance for the specied broker url
-    """
+    """Return a consumer instance for the specied broker url."""
     if broker.startswith("kafka"):
         return KafkaConsumer(broker=broker, topic=topic, group=group)
     if broker.startswith("dummy"):
@@ -31,9 +27,7 @@ Consumer = consumer_factory  # pylint: disable=invalid-name
 
 
 def producer_factory(broker: str) -> BaseProducer:
-    """
-    Return a producer instance for the specied broker url
-    """
+    """Return a producer instance for the specied broker url."""
     if broker.startswith("kafka"):
         return KafkaProducer(broker)
     if broker.startswith("dummy"):

--- a/eventbusk/brokers/base.py
+++ b/eventbusk/brokers/base.py
@@ -1,6 +1,4 @@
-"""
-Base interface for event consumer and producers.
-"""
+"""Base interface for event consumer and producers."""
 
 from __future__ import annotations
 
@@ -8,10 +6,12 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import ContextDecorator
-from types import TracebackType
-from typing import Union
+from typing import TYPE_CHECKING, Self
 
 from confluent_kafka import cimpl  # type: ignore
+
+if TYPE_CHECKING:
+    from types import TracebackType
 
 logger = logging.getLogger(__name__)
 
@@ -25,25 +25,20 @@ __all__ = [
 # Type hints
 # callback method `on_delivery` on the producer
 DeliveryCallBackT = Callable[..., None]
-MessageT = Union[str, bytes, cimpl.Message]  # pylint: disable=invalid-name
+MessageT = str | bytes | cimpl.Message  # pylint: disable=invalid-name
 
 
 class BaseBrokerURI(ABC):
-    """
-    Base class that defines the interface for all broker URIs
-    """
+    """Base class that defines the interface for all broker URIs."""
 
     @classmethod
     @abstractmethod
     def from_uri(cls, uri: str) -> BaseBrokerURI:
-        """
-        Return a instance created from a URI
-        """
+        """Return a instance created from a URI."""
 
 
 class BaseConsumer(ContextDecorator, ABC):
-    """
-    Base class for consumers
+    """Base class for consumers.
 
     All event consumers are exposed as a ContextDecorator, so it can be used via a
     `with` statement and any connections are automatically closed on exit.
@@ -61,7 +56,7 @@ class BaseConsumer(ContextDecorator, ABC):
             f"group='{self.group}')>"
         )
 
-    def __enter__(self) -> BaseConsumer:
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(  # pylint: disable=too-many-positional-arguments
@@ -74,27 +69,21 @@ class BaseConsumer(ContextDecorator, ABC):
 
     @abstractmethod
     def poll(self, timeout: int) -> MessageT | None:  # type: ignore
-        """
-        Poll for a specified time in seconds for new messages
-        """
+        """Poll for a specified time in seconds for new messages."""
 
     @abstractmethod
     def ack(self, message: str) -> None:
-        """
-        Acknowledge successful consumption of a message.
-        """
+        """Acknowledge successful consumption of a message."""
 
 
 class BaseProducer(ABC):
-    """
-    Base class for producers
-    """
+    """Base class for producers."""
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}(broker=*>"
 
     @abstractmethod
-    def __init__(self, broker: str):
+    def __init__(self, broker: str) -> None:
         super().__init__()
 
     @abstractmethod
@@ -107,11 +96,10 @@ class BaseProducer(ABC):
         on_delivery: DeliveryCallBackT = None,
         fail_silently: bool = False,
     ) -> None:
-        """
-        Send a message on the specific topic.
+        """Send a message on the specific topic.
 
-        Arguments
-        ----------
+        Arguments:
+        ---------
         topic:
             The name of the topic
         value:
@@ -123,4 +111,5 @@ class BaseProducer(ABC):
             Useful for brokers like Kafka which do batches.
         fail_silently:
             If True, ignore all delivery errors.
+
         """

--- a/eventbusk/brokers/dummy.py
+++ b/eventbusk/brokers/dummy.py
@@ -1,5 +1,4 @@
-"""
-Dummy broker for use cases where a real implementation of the event bus is not
+"""Dummy broker for use cases where a real implementation of the event bus is not
 required, eg. CI pipelines.
 """
 
@@ -27,8 +26,7 @@ __all__ = [
 
 @dataclass
 class BrokerURI(BaseBrokerURI):
-    """
-    Broker URI
+    """Broker URI.
 
     Basic url is of the format: dummy://
 
@@ -39,9 +37,7 @@ class BrokerURI(BaseBrokerURI):
 
     @classmethod
     def from_uri(cls, uri: str) -> BrokerURI:
-        """
-        Instantiate from a URI like "dummy://"
-        """
+        """Instantiate from a URI like "dummy://"."""
         invalid_format = ValueError("Broker URI should be of the format 'dummy://'")
 
         if not uri.startswith("dummy://"):
@@ -51,13 +47,13 @@ class BrokerURI(BaseBrokerURI):
 
 
 class Consumer(BaseConsumer):
-    """
-    Dummy event consumer which simply loses all events!
+    """Dummy event consumer which simply loses all events.
 
-    Example
+    Example:
     -------
     >>> with DummyConsumer(broker, topic, group) as consumer:
            ...
+
     """
 
     broker: BrokerURI
@@ -69,23 +65,17 @@ class Consumer(BaseConsumer):
         self.group = group
 
     def poll(self, timeout: int = 1) -> MessageT | None:
-        """
-        Sleeps for the required timeout, and returns no message.
-        """
+        """Sleeps for the required timeout, and returns no message."""
         time.sleep(timeout)
 
     def ack(self, message: MessageT) -> None:
-        """
-        Acknowledge event
-        """
+        """Acknowledge event."""
 
 
 class Producer(BaseProducer):
-    """
-    Dummy event producer.
-    """
+    """Dummy event producer."""
 
-    def __init__(self, broker: str):
+    def __init__(self, broker: str) -> None:
         super().__init__(broker)
         self.broker = BrokerURI.from_uri(broker)
 
@@ -98,9 +88,7 @@ class Producer(BaseProducer):
         on_delivery: DeliveryCallBackT = None,
         fail_silently: bool = False,
     ) -> None:
-        """
-        Only logs the message, does not deliver.
-        """
+        """Only logs the message, does not deliver."""
         logger.info(
             f"Producing message {value=}.",
             extra={

--- a/eventbusk/brokers/kafka.py
+++ b/eventbusk/brokers/kafka.py
@@ -1,13 +1,10 @@
-"""
-Kafka Broker
-"""
+"""Kafka Broker."""
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from types import TracebackType
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Self
 
 from confluent_kafka import (  # type: ignore
     Consumer as CConsumer,
@@ -19,6 +16,8 @@ from ..exceptions import ProducerError
 from .base import BaseBrokerURI, BaseConsumer, BaseProducer
 
 if TYPE_CHECKING:
+    from types import TracebackType
+
     from .base import DeliveryCallBackT, MessageT
 
 
@@ -31,13 +30,12 @@ __all__ = [
     "Producer",
 ]
 
-ConfigT = dict[str, Union[bool, int, str]]
+ConfigT = dict[str, bool | int | str]
 
 
 @dataclass
 class BrokerURI(BaseBrokerURI):
-    """
-    Broker URI
+    """Broker URI.
 
     Basic url is of the format: kafka://localhost:9092
     SASL support is enabled with the format: kafkas://user:pass@localhost:9092
@@ -57,12 +55,10 @@ class BrokerURI(BaseBrokerURI):
 
     @classmethod
     def from_uri(cls, uri: str) -> BrokerURI:
-        """
-        Return an instance from a string URI
-        """
+        """Return an instance from a string URI."""
         invalid_format = ValueError(
             "Broker URI(without SASL) should be of the format 'kafka://host:port' "
-            "or 'kafkas://user:pass@host:port'"
+            "or 'kafkas://user:pass@host:port'",
         )
 
         if uri.startswith("kafka://"):
@@ -104,9 +100,7 @@ class BrokerURI(BaseBrokerURI):
 
     @property
     def default_config(self) -> ConfigT:
-        """
-        Default configuration for consumer or producer instances
-        """
+        """Default configuration for consumer or producer instances."""
         props: ConfigT = {
             "bootstrap.servers": f"{self.host}:{self.port}",
         }
@@ -117,26 +111,26 @@ class BrokerURI(BaseBrokerURI):
                     "security.protocol": "SASL_SSL",
                     "sasl.username": self.username,
                     "sasl.password": self.password,
-                }
+                },
             )
         return props.copy()
 
 
 class Consumer(BaseConsumer):
-    """
-    Kafka consumer as a context manager.
+    """Kafka consumer as a context manager.
 
     Automatically closes the consumer at the end of the context manager block.
 
-    Example
+    Example:
     -------
     >>> with KafkaConsumer(broker, topic, group) as consumer:
            ...
+
     """
 
     broker: BrokerURI
 
-    def __init__(self, broker: str, *, topic: str, group: str):
+    def __init__(self, broker: str, *, topic: str, group: str) -> None:
         super().__init__()
         self.broker = BrokerURI.from_uri(broker)
         self.topic = topic
@@ -151,14 +145,14 @@ class Consumer(BaseConsumer):
             f"group='{self.group}')>"
         )
 
-    def __enter__(self) -> Consumer:
+    def __enter__(self) -> Self:
         config = self.broker.default_config
         config.update(
             {
                 "group.id": self.group,
                 "auto.offset.reset": "latest",  # TODO: This will change per receiver
                 "enable.auto.commit": False,
-            }
+            },
         )
         self._consumer = CConsumer(config)
         self._consumer.subscribe([self.topic])
@@ -184,24 +178,18 @@ class Consumer(BaseConsumer):
             )
 
     def poll(self, timeout: int) -> MessageT | None:
-        """
-        Poll the topic for new messages
-        """
+        """Poll the topic for new messages."""
         return self._consumer.poll(timeout)
 
     def ack(self, message: MessageT | None) -> None:
-        """
-        Acknowledge the message by explicitly committing.
-        """
+        """Acknowledge the message by explicitly committing."""
         self._consumer.commit(message=message)
 
 
 class Producer(BaseProducer):
-    """
-    Kafka event producer.
-    """
+    """Kafka event producer."""
 
-    def __init__(self, broker: str):
+    def __init__(self, broker: str) -> None:
         super().__init__(broker)
         self.broker = BrokerURI.from_uri(broker)
         config = self.broker.default_config
@@ -216,9 +204,7 @@ class Producer(BaseProducer):
         on_delivery: DeliveryCallBackT = None,
         fail_silently: bool = False,
     ) -> None:
-        """
-        Sends the message to a Kafka topic
-        """
+        """Sends the message to a Kafka topic."""
         logger.debug(
             "Producing message.",
             extra={

--- a/eventbusk/bus.py
+++ b/eventbusk/bus.py
@@ -1,6 +1,4 @@
-"""
-EventBus implementation
-"""
+"""EventBus implementation."""
 
 from __future__ import annotations
 
@@ -21,24 +19,22 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class Event(ABC):
-    """
-    Every new event must inherit this class and should be a dataclass.
+    """Every new event must inherit this class and should be a dataclass.
 
-    Example
+    Example:
     -------
     @dataclass
     class MyEvent(Event):
         foo: int
         bar: str
+
     """
 
     event_id: uuid.UUID = field(default_factory=uuid.uuid4, init=False)
 
 
 class EventJsonEncoder(json.JSONEncoder):
-    """
-    JSON encoder that additionally converts uuid to str.
-    """
+    """JSON encoder that additionally converts uuid to str."""
 
     def default(self, o):
         if isinstance(o, uuid.UUID):
@@ -55,8 +51,7 @@ HooksT = list[HookT] | None  # pylint: disable=invalid-name
 
 
 class EventBus:
-    """
-    An EventBus is an a concrete instance of an event bus.
+    """An EventBus is an a concrete instance of an event bus.
 
     It is akin to a WSGI Application, or Celery instance.  A project might contain
     multiple instances of the bus connected to different brokers.
@@ -94,7 +89,7 @@ class EventBus:
         *,
         before_receive: HooksT = None,
         after_receive: HooksT = None,
-    ):
+    ) -> None:
         self.broker = broker
         self._before_receive_hooks: list[HookT] = self._to_hook_list(before_receive)
         self._after_receive_hooks: list[HookT] = self._to_hook_list(after_receive)
@@ -116,15 +111,13 @@ class EventBus:
 
     @staticmethod
     def to_fqn(event_type: EventT | ReceiverT) -> str:
-        """
-        Returns 'fully qualified name' of an event class or an receiver, to identify
+        """Returns 'fully qualified name' of an event class or an receiver, to identify
         them uniquely.
         """
         return f"{event_type.__module__}.{event_type.__qualname__}"
 
     def register_event(self, topic: str, event_type: EventT) -> None:
-        """
-        Register an event to a bus.
+        """Register an event to a bus.
 
         Each event is only linked to a single topic.
         """
@@ -146,9 +139,7 @@ class EventBus:
         flush: bool = True,
         fail_silently: bool = False,
     ) -> None:
-        """
-        Send an event on the bus.
-        """
+        """Send an event on the bus."""
         if self.producer is None:
             self.producer = Producer(broker=self.broker)
 
@@ -159,9 +150,12 @@ class EventBus:
 
         try:
             self.producer.produce(
-                topic=topic, value=data, flush=flush, on_delivery=on_delivery
+                topic=topic,
+                value=data,
+                flush=flush,
+                on_delivery=on_delivery,
             )
-        except ProducerError as exc:
+        except ProducerError:
             if fail_silently:
                 logger.warning(
                     "Error producing event.",
@@ -173,21 +167,20 @@ class EventBus:
                     exc_info=True,
                 )
             else:
-                raise exc
+                raise
 
     @property
     def receivers(self) -> set[ReceiverWrappedT]:
-        """
-        Returns a set of receivers(consumers) of events.
-        """
+        """Returns a set of receivers(consumers) of events."""
         return self._receivers
 
     # TODO: add group parameter?
     def receive(  # pylint: disable=too-complex
-        self, event_type: EventT, poll_timeout: int = 1
+        self,
+        event_type: EventT,
+        poll_timeout: int = 1,
     ) -> ReceivedOuterT:
-        """
-        Decorator to convert a function into an receiver.
+        """Decorator to convert a function into an receiver.
 
         An receiver is a simple function that consumes a specific event on the event
         bus.
@@ -196,7 +189,7 @@ class EventBus:
         if event_fqn not in self._event_to_topic:
             raise UnknownEvent(
                 "Register the event to a topic using "
-                f"`bus.register_event('foo_topic', {event_type})`"
+                f"`bus.register_event('foo_topic', {event_type})`",
             )
 
         def _outer(func: ReceiverT) -> ReceiverWrappedT:
@@ -246,7 +239,7 @@ class EventBus:
                                     msg,
                                     extra={
                                         **log_context,
-                                        **{"error": msg_error},
+                                        "error": msg_error,
                                     },
                                 )
                                 self.sleep(seconds=1, message=msg)
@@ -265,7 +258,7 @@ class EventBus:
                                 except ValueError:
                                     logger.exception(
                                         ("Error while converting str -> UUID "),
-                                        extra={**log_context, **{"data": event_data}},
+                                        extra={**log_context, "data": event_data},
                                         exc_info=True,
                                     )
                             else:
@@ -274,7 +267,7 @@ class EventBus:
                             # TODO: Fix following
                             # Too many arguments for "Event"  [call-arg]
                             event = event_type(**event_data)  # type: ignore
-                            setattr(event, "event_id", event_id)
+                            event.event_id = event_id
 
                             for hook in self._before_receive_hooks:
                                 try:
@@ -295,7 +288,7 @@ class EventBus:
                                         "Error while processing event. "
                                         "topic might be blocked"
                                     ),
-                                    extra={**log_context, **{"data": event}},
+                                    extra={**log_context, "data": event},
                                     exc_info=True,
                                 )
                                 success = False
@@ -338,8 +331,6 @@ class EventBus:
 
     @staticmethod
     def sleep(seconds: int = 1, message: str = "") -> None:
-        """
-        Helper to sleep and log a custom message
-        """
+        """Helper to sleep and log a custom message."""
         logger.info(f"Sleeping for {seconds}s. {message}")
         time.sleep(seconds)

--- a/eventbusk/cli.py
+++ b/eventbusk/cli.py
@@ -1,22 +1,23 @@
-"""
-Command Line Interface
-"""
+"""Command Line Interface."""
 
 from __future__ import annotations
 
 import importlib
 import logging
-import os
 import sys
 import threading
-from collections.abc import Callable, Generator
 from contextlib import contextmanager, suppress
+from pathlib import Path
 from types import ModuleType
+from typing import TYPE_CHECKING
 
 import click
 import cotyledon  # type: ignore
 
 from .bus import EventBus
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +25,7 @@ logger = logging.getLogger(__name__)
 @contextmanager
 def cwd_in_path() -> Generator[str | None]:
     """Context adding the current working directory to sys.path."""
-    cwd = os.getcwd()
+    cwd = str(Path.cwd())
     if cwd in sys.path:
         yield None
     else:
@@ -37,18 +38,18 @@ def cwd_in_path() -> Generator[str | None]:
 
 
 def find_app(app: str, attr_name: str = "app") -> EventBus:
-    """
-    Import an EventBus instance based on a path name.
+    """Import an EventBus instance based on a path name.
 
-    Arguments
-    ----------
+    Arguments:
+    ---------
     app: str
         Path to a module containing an EventBus instance.
 
-    Keyword Arguments
-    ------------------
+    Keyword Arguments:
+    -----------------
     attr_name: str
        Name of the EventBus instance inside the app. Defaults to 'app'.
+
     """
     if ":" in app:
         module_name, attr_name = app.split(":")
@@ -59,13 +60,15 @@ def find_app(app: str, attr_name: str = "app") -> EventBus:
         module = importlib.import_module(module_name, package=None)
 
     if not isinstance(module, ModuleType):
-        raise AttributeError(f"Module f{module_name} not found or cannot be imported")
+        msg = f"Module f{module_name} not found or cannot be imported"
+        raise AttributeError(msg)
 
     # Find bus instance within the module
     found = getattr(module, attr_name)
     if not isinstance(found, EventBus):
+        msg = f"EventBus instance {attr_name} not found in {module_name}"
         raise AttributeError(
-            f"EventBus instance {attr_name} not found in {module_name}"
+            msg,
         )
 
     return found
@@ -102,9 +105,7 @@ class Worker(cotyledon.Service):  # type: ignore
 @cli.command()
 @click.option("--app", "-A", help="Path to EventBus instance. eg. 'mymodule:app'")
 def worker(app: str) -> None:
-    """
-    Start consumer workers
-    """
+    """Start consumer workers."""
     bus = find_app(app)
     receivers = bus.receivers
     if not receivers:

--- a/eventbusk/exceptions.py
+++ b/eventbusk/exceptions.py
@@ -1,6 +1,4 @@
-"""
-Custom exceptions
-"""
+"""Custom exceptions."""
 
 from __future__ import annotations
 
@@ -13,30 +11,20 @@ __all__ = [
 
 
 class EventBusError(Exception):
-    """
-    Base of exceptions raised by the bus.
-    """
+    """Base of exceptions raised by the bus."""
 
 
 class UnknownEvent(EventBusError):
-    """
-    Raised when an receiver is created for an event the bus does not recognize.
-    """
+    """Raised when an receiver is created for an event the bus does not recognize."""
 
 
 class AlreadyRegistered(EventBusError):
-    """
-    Raised when an event is registered more than once to the bus.
-    """
+    """Raised when an event is registered more than once to the bus."""
 
 
 class ProducerError(EventBusError):
-    """
-    Raised during production of an event.
-    """
+    """Raised during production of an event."""
 
 
 class ConsumerError(EventBusError):
-    """
-    Raised during consumption of an event
-    """
+    """Raised during consumption of an event."""

--- a/examples/eventbus.py
+++ b/examples/eventbus.py
@@ -1,5 +1,4 @@
-"""
-Run workers for the receivers via
+"""Run workers for the receivers via.
 
 $>eventbusk worker -A eventbus:bus
 
@@ -28,18 +27,14 @@ bus = EventBus(broker="kafka://localhost:9092")
 
 @dataclass
 class Fooey(Event):
-    """
-    First type of event
-    """
+    """First type of event."""
 
     foo_val: int
 
 
 @dataclass
 class Barzy(Event):
-    """
-    Second type of event
-    """
+    """Second type of event."""
 
     bar_val: str
 
@@ -51,15 +46,11 @@ bus.register_event("topic_bar", Barzy)
 # Consume an event
 @bus.receive(event_type=Fooey)
 def process_a(event: Event) -> None:
-    """
-    Consumer of Foeey events
-    """
+    """Consumer of Foeey events."""
     logger.info(f"Foo: {event}")
 
 
 @bus.receive(event_type=Barzy)
 def process_b(event: Event) -> None:
-    """
-    Consumer of Barzy events
-    """
+    """Consumer of Barzy events."""
     logger.info(f"Bar: {event}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,80 @@ line-length = 88
 target-version = "py313"
 
 [tool.ruff.lint]
-extend-select = ["E501", "I"]
+select = ["ALL"]
+ignore = [
+    # Conflicting rules
+    "D203",    # blank-line-before-class: conflicts with D211
+    "D213",    # multi-line-summary-second-line: conflicts with D212
+
+    # Docstring style (too opinionated / would add boilerplate)
+    "D102",    # undocumented-public-method
+    "D104",    # undocumented-public-package
+    "D105",    # undocumented-magic-method
+    "D107",    # undocumented-public-init
+    "D205",    # missing-blank-line-after-summary
+    "D401",    # non-imperative-mood
+    "D402",    # signature-in-docstring
+
+    # Exception message style (opinionated)
+    "TRY003",  # raise-vanilla-args: long messages outside exception class
+    "TRY004",  # type-check-without-type-error
+    "EM101",   # raw-string-in-exception: assigning to msg variable first
+    "EM102",   # f-string-in-exception: assigning to msg variable first
+
+    # Conflicts with the ruff formatter
+    "COM812",  # missing-trailing-comma (formatter handles this)
+
+    # Logging style (project consistently uses f-strings)
+    "G004",    # logging-f-string
+    "G202",    # logging-redundant-exc-info (intentional in except blocks)
+
+    # TODO annotations (intentional TODOs exist in codebase)
+    "FIX002",  # line-contains-todo
+    "TD002",   # missing-todo-author
+    "TD003",   # missing-todo-link
+
+    # Type annotation permissiveness
+    "ANN401",  # any-type (needed for *args/**kwargs)
+    "ANN001",  # missing-type-function-argument (covered by mypy)
+    "ANN201",  # missing-return-type-undocumented-public-function (covered by mypy)
+
+    # Complexity metrics (require refactoring, not linting fixes)
+    "C901",    # complex-structure
+    "PLR0912", # too-many-branches
+    "PLR0915", # too-many-statements
+
+    # Test patterns that are intentional
+    "SLF001",  # private-member-access (legitimate for testing internals)
+    "PLR2004", # magic-value-comparison (well-known constants like port 9092)
+    "PT028",   # pytest-parameter-with-default-argument
+    "PT011",   # pytest-raises-too-broad
+
+    # blanket type: ignore (third-party libs without stubs)
+    "PGH003",  # blanket-type-ignore
+
+    # Commented-out code used as intentional documentation
+    "ERA001",  # commented-out-code
+
+    # Would break public API to rename
+    "N818",    # error-suffix-on-exception-name (UnknownEvent, AlreadyRegistered)
+
+    # examples/ is not a package
+    "INP001",  # implicit-namespace-package
+
+    # Misc
+    "LOG014",  # exc-info-outside-except-handler
+    "ARG001",  # unused-function-argument (interface methods, test event handlers)
+    "ARG002",  # unused-method-argument (interface methods)
+    "S105",    # hardcoded-password-string (test assertion, not real password)
+    "B024",    # abstract-base-class-without-abstract-method
+    "TID252",  # relative-imports (used throughout the package)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+    "S101",   # assert: fine in tests
+]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/tests/test_brokers.py
+++ b/tests/test_brokers.py
@@ -1,14 +1,11 @@
-"""
-Test broker implementation
-"""
+"""Test broker implementation."""
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from confluent_kafka import KafkaError  # type: ignore
-from pytest_mock import MockerFixture
 
 from eventbusk.brokers import Consumer, Producer
 from eventbusk.brokers.dummy import (
@@ -23,11 +20,14 @@ from eventbusk.brokers.kafka import (
 )
 from eventbusk.exceptions import ProducerError
 
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
 
 # Factories
 # ---------
 @pytest.mark.parametrize(
-    "broker,topic,group",
+    ("broker", "topic", "group"),
     [
         ("kafka://localhost:9092", "mytopic", "mygroup"),
         ("kafkas://username:password@localhost:9092", "mytopic", "mygroup"),
@@ -35,9 +35,7 @@ from eventbusk.exceptions import ProducerError
     ],
 )
 def test_consumer_factory(broker: str, topic: str, group: str) -> None:
-    """
-    Test consumer factory returns the correct instance for a given broker URI.
-    """
+    """Test consumer factory returns the correct instance for a given broker URI."""
     # Given broker uri, and optionally topic and group
 
     # When a consumer is instantiated with the broker and dummy topic, group
@@ -70,7 +68,7 @@ def test_consumer_factory(broker: str, topic: str, group: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "broker,topic,group",
+    ("broker", "topic", "group"),
     [
         ("", "mytopic", "mygroup"),
         ("kafka://username:password@localhost:9092", "mytopic", "mygroup"),
@@ -83,16 +81,15 @@ def test_consumer_factory(broker: str, topic: str, group: str) -> None:
     ],
 )
 def test_consumer_factory_bad_broker(broker: str, topic: str, group: str) -> None:
-    """
-    Test if consumer factory errors out on an invalid broker uri
-    """
+    """Test if consumer factory errors out on an invalid broker uri."""
     # Given invalid broker uri
 
     # Then ensure it raises an exception
-    with pytest.raises(ValueError):
-        # When Consumer is instantiated
-        with Consumer(broker=broker, topic=topic, group=group) as consumer:
-            assert consumer is not None
+    with (
+        pytest.raises(ValueError),
+        Consumer(broker=broker, topic=topic, group=group) as consumer,
+    ):
+        assert consumer is not None
 
 
 @pytest.mark.parametrize(
@@ -104,9 +101,7 @@ def test_consumer_factory_bad_broker(broker: str, topic: str, group: str) -> Non
     ],
 )
 def test_producer_factory(broker: str) -> None:
-    """
-    Test if producer factory returns the correct producer.
-    """
+    """Test if producer factory returns the correct producer."""
     # Given a broker URI
 
     # When a producer is initialized
@@ -126,9 +121,7 @@ def test_producer_factory(broker: str) -> None:
     ["foobar://"],
 )
 def test_producer_factory_bad_broker(broker: str) -> None:
-    """
-    Test if producer factory raises exception on invalid broker URI
-    """
+    """Test if producer factory raises exception on invalid broker URI."""
     # Given a broker URI
 
     # Then ensure an exception is raised
@@ -140,17 +133,13 @@ def test_producer_factory_bad_broker(broker: str) -> None:
 # Dummy broker
 # -------------
 def test_dummy_producer() -> None:
-    """
-    Test basic dummy producer functionality
-    """
+    """Test basic dummy producer functionality."""
     producer = DummyProducer(broker="dummy://")
     producer.produce(topic="foo", value="lorem ipsum")
 
 
 def test_dummy_consumer() -> None:
-    """
-    Test basic dummy consumer functionality
-    """
+    """Test basic dummy consumer functionality."""
     consumer = DummyConsumer(broker="dummy://", topic="mytopic", group="mygroup")
     assert isinstance(consumer.broker, DummyBrokerURI)
     assert consumer.topic == "mytopic"
@@ -163,9 +152,7 @@ def test_dummy_consumer() -> None:
 # Kafka broker
 # -------------
 def test_kafka_broker_uri() -> None:
-    """
-    Test BrokerURI functionality
-    """
+    """Test BrokerURI functionality."""
     with pytest.raises(ValueError):
         KafkaBrokerURI.from_uri("foobar://localhost:9092")
 
@@ -177,11 +164,11 @@ def test_kafka_broker_uri() -> None:
 
 
 def test_kafka_producer(
-    mocker: MockerFixture, topic: str = "foo", value: str = "lorem ipsum"
+    mocker: MockerFixture,
+    topic: str = "foo",
+    value: str = "lorem ipsum",
 ) -> None:
-    """
-    Test producing to kafka
-    """
+    """Test producing to kafka."""
     # Given a Kafka producer that
     # mocks the underlying confluent producer so it doesn't try to connect
     cproducer = mocker.Mock()
@@ -192,7 +179,9 @@ def test_kafka_producer(
     producer.produce(topic=topic, value=value)
     # Then ensure underlying producer is called
     cproducer.produce.assert_called_once_with(
-        topic="foo", value=value, on_delivery=None
+        topic="foo",
+        value=value,
+        on_delivery=None,
     )
     cproducer.flush.assert_called_once()
 
@@ -203,17 +192,17 @@ def test_kafka_producer(
 
 
 def test_kafka_producer_error(
-    mocker: MockerFixture, topic: str = "foo", value: str = "lorem ipsum"
+    mocker: MockerFixture,
+    topic: str = "foo",
+    value: str = "lorem ipsum",
 ) -> None:
-    """
-    Test kafka producer error handling
-    """
+    """Test kafka producer error handling."""
     # Given a producer that errors out
     cproducer = mocker.Mock()
 
     def raise_exc(*args: Any, **kwargs: Any) -> None:
         raise KafkaError(  # pylint: disable=raising-non-exception
-            KafkaError.BROKER_NOT_AVAILABLE
+            KafkaError.BROKER_NOT_AVAILABLE,
         )
 
     cproducer.produce.side_effect = raise_exc
@@ -231,18 +220,20 @@ def test_kafka_producer_error(
 
 
 def test_kafka_consumer(
-    mocker: MockerFixture, message: str = "lorem ipsum", timeout: int = 0
+    mocker: MockerFixture,
+    message: str = "lorem ipsum",
+    timeout: int = 0,
 ) -> None:
-    """
-    Test basic kafka consumer functionality
-    """
+    """Test basic kafka consumer functionality."""
     # Given a Kafka consumer with a mocked underlying Confluent consumer
     # to avoid making a connection
     cconsumer = mocker.Mock()
     cconsumer.poll.return_value = message
     mocker.patch("eventbusk.brokers.kafka.CConsumer", return_value=cconsumer)
     with KafkaConsumer(
-        broker="kafka://localhost:9092", topic="mytopic", group="mygroup"
+        broker="kafka://localhost:9092",
+        topic="mytopic",
+        group="mygroup",
     ) as consumer:
         assert repr(consumer)
 

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -1,6 +1,4 @@
-"""
-Test EventBus implementation
-"""
+"""Test EventBus implementation."""
 
 from __future__ import annotations
 
@@ -8,29 +6,27 @@ import json
 import logging
 import uuid
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
-from pytest_mock import MockerFixture
-
 from eventbusk import Event, EventBus
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class Foo(Event):
-    """
-    Dummy event
-    """
+    """Dummy event."""
 
     first: int
 
 
 @dataclass
 class Bar(Event):
-    """
-    Dummy event
-    """
+    """Dummy event."""
 
     second: int
 
@@ -39,8 +35,7 @@ BROKER = "kafka://localhost:9092"
 
 
 def _make_mock_consumer(event_data: dict) -> tuple[MagicMock, MagicMock]:
-    """
-    Create a mock Consumer that yields one message with the given event data,
+    """Create a mock Consumer that yields one message with the given event data,
     then raises KeyboardInterrupt to exit the receive loop.
     """
     message = MagicMock()
@@ -55,9 +50,7 @@ def _make_mock_consumer(event_data: dict) -> tuple[MagicMock, MagicMock]:
 
 
 def test_bus_send(mocker: MockerFixture) -> None:
-    """
-    Test basic producer
-    """
+    """Test basic producer."""
     # Given an instance of an event bus
     producer = mocker.Mock()
     mocker.patch("eventbusk.bus.Producer", return_value=producer)
@@ -76,9 +69,7 @@ def test_bus_send(mocker: MockerFixture) -> None:
 
     # When we send events of a different types
     def on_delivery(error: str, event: Event) -> None:
-        """
-        Do nothing delivery handler
-        """
+        """Do nothing delivery handler."""
         logger.info(error, event)
 
     bus.send(foo_event, on_delivery=on_delivery)
@@ -91,7 +82,8 @@ def test_bus_send(mocker: MockerFixture) -> None:
             mocker.call(
                 topic="first_topic",
                 value=bytes(
-                    f'{{"event_id": "{str(foo_event_uuid)}", "first": 1}}', "utf-8"
+                    f'{{"event_id": "{foo_event_uuid!s}", "first": 1}}',
+                    "utf-8",
                 ),
                 flush=True,
                 on_delivery=on_delivery,
@@ -99,19 +91,18 @@ def test_bus_send(mocker: MockerFixture) -> None:
             mocker.call(
                 topic="second_topic",
                 value=bytes(
-                    f'{{"event_id": "{str(bar_event_uuid)}", "second": 1}}', "utf-8"
+                    f'{{"event_id": "{bar_event_uuid!s}", "second": 1}}',
+                    "utf-8",
                 ),
                 flush=True,
                 on_delivery=on_delivery,
             ),
-        ]
+        ],
     )
 
 
 def test_bus_receive() -> None:
-    """
-    Test basic consumer
-    """
+    """Test basic consumer."""
     # Given an instance of an event bus
     bus = EventBus(broker=BROKER)
 


### PR DESCRIPTION
## Summary

Enables `select = ["ALL"]` in ruff so every available rule category is active, then consciously ignores 39 rule codes that are too opinionated, would break the public API, or represent legitimate patterns in this codebase.

## What changed

### `pyproject.toml`
- Switched from `extend-select = ["E501", "I"]` to `select = ["ALL"]`
- Added documented `ignore` list (see inline comments for rationale per rule)
- Kept `tests/**` ignoring `S101` (asserts are fine in tests)

### Auto-fixed (285 violations)
- Docstring formatting: multiline → single-line, trailing periods added
- `TYPE_CHECKING` blocks for type-only imports (`MockerFixture`, `TracebackType`)
- `__init__` annotated `-> None` (`ANN204`), `Union[X,Y]` → `X | Y` (`UP007`)
- `__all__` sorted, trailing commas, import ordering, and misc cleanups

### Manual fixes (4 violations)
- `os.getcwd()` → `str(Path.cwd())` in `cli.py` (`PTH109`)
- `Union[str, bytes, cimpl.Message]` → `str | bytes | cimpl.Message` (`UP007`)
- Bare `raise` instead of `raise exc` (`TRY201`)
- Nested `with` statements combined in `test_brokers.py` (`SIM117`)

### Consciously ignored (163 violations, 39 rule codes)
| Code | Reason |
|------|--------|
| `D203/D213` | Conflicting rules — disabled in favour of `D211`/`D212` |
| `COM812` | Conflicts with the ruff formatter (handled automatically) |
| `D102/104/105/107` | Missing docstrings — would add boilerplate |
| `D205/401/402` | Opinionated docstring style |
| `EM101/EM102` | Exception message style — opinionated pattern enforcement |
| `G004` | Logging f-strings — project's consistent style |
| `G202` | Redundant `exc_info` — intentional in except blocks |
| `TRY003/004` | Exception message style — opinionated |
| `N818` | Exception naming — would break public API |
| `FIX002/TD002/TD003` | TODO format — intentional TODOs exist |
| `ERA001` | Commented-out code used as documentation |
| `PGH003` | Blanket `type: ignore` — third-party libs without stubs |
| `SLF001` | Private member access — legitimate in tests |
| `C901/PLR0912/PLR0915` | Complexity — requires refactoring, not style |
| `PLR2004` | Magic values — well-known constants (e.g. port 9092) |
| `PT028/PT011` | pytest patterns that are intentional |
| `ANN401/ANN001/ANN201` | Covered by mypy config |
| `ARG001/ARG002` | Unused args in interface methods and test handlers |
| `TID252` | Relative imports — used throughout the package |
| `B024/INP001/LOG014/S105` | Misc — see pyproject.toml comments |

## Testing
All 27 tests pass.
