### PR TITLE
fix: catch KafkaException instead of KafkaError

### DIFF
--- a/eventbusk/brokers/kafka.py
+++ b/eventbusk/brokers/kafka.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Self
 
 from confluent_kafka import (  # type: ignore
     Consumer as CConsumer,
-    KafkaError,
+    KafkaException,
     Producer as CProducer,
 )
 
@@ -218,14 +218,12 @@ class Producer(BaseProducer):
             self._producer.produce(topic=topic, value=value, on_delivery=on_delivery)
             if flush:
                 self._producer.flush()
-        except KafkaError as exc:  # pylint: disable=catching-non-exception
+        except KafkaException as exc:
             if fail_silently:
                 logger.warning(
                     "Error producing event.",
                     extra={"topic": topic, "flush": flush},
-                    # Cannot add exc_info=True because of
-                    # AttributeError: 'cimpl.KafkaError' object has no
-                    #    attribute '__traceback__'
+                    exc_info=True,
                 )
             else:
-                raise ProducerError from exc  # pylint: disable=bad-exception-cause
+                raise ProducerError from exc

--- a/tests/test_brokers.py
+++ b/tests/test_brokers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import pytest
-from confluent_kafka import KafkaError  # type: ignore
+from confluent_kafka import KafkaError, KafkaException  # type: ignore
 
 from eventbusk.brokers import Consumer, Producer
 from eventbusk.brokers.dummy import (
@@ -201,9 +201,7 @@ def test_kafka_producer_error(
     cproducer = mocker.Mock()
 
     def raise_exc(*args: Any, **kwargs: Any) -> None:
-        raise KafkaError(  # pylint: disable=raising-non-exception
-            KafkaError.BROKER_NOT_AVAILABLE,
-        )
+        raise KafkaException(KafkaError(KafkaError.BROKER_NOT_AVAILABLE))
 
     cproducer.produce.side_effect = raise_exc
     mocker.patch("eventbusk.brokers.kafka.CProducer", return_value=cproducer)


### PR DESCRIPTION
## Problem

`KafkaError` is a raw Cython type (`cimpl.KafkaError`) that inherits only from `object`, not `BaseException`. Catching it in a Python `except` clause is technically unsound — pylint correctly flags it as `catching-non-exception`. A side-effect was that `KafkaError` instances have no `__traceback__` attribute, so `exc_info=True` could not be used in the warning log.

## Fix

Replace `KafkaError` with `KafkaException`, which is the proper Python `Exception` subclass that `confluent_kafka` raises in Python contexts.

## Changes
- Catch `KafkaException` (proper `Exception` subclass) instead of `KafkaError` (bare Cython type)
- Restore `exc_info=True` in the `fail_silently` warning logger
- Remove `# pylint: disable=catching-non-exception` suppression
- Remove `# pylint: disable=bad-exception-cause` suppression