### PR TITLE
Modernize type aliases: use PEP 695 type keyword, drop T suffix

### DIFF
--- a/eventbusk/brokers/__init__.py
+++ b/eventbusk/brokers/__init__.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import logging
 
-from .base import BaseConsumer, BaseProducer, DeliveryCallBackT
+from .base import BaseConsumer, BaseProducer, DeliveryCallback
 from .dummy import Consumer as DummyConsumer, Producer as DummyProducer
 from .kafka import Consumer as KafkaConsumer, Producer as KafkaProducer
 
 logger = logging.getLogger(__name__)
 
 
-__all__ = ["Consumer", "DeliveryCallBackT", "Producer"]
+__all__ = ["Consumer", "DeliveryCallback", "Producer"]
 
 
 def consumer_factory(broker: str, topic: str, group: str) -> BaseConsumer:

--- a/eventbusk/brokers/base.py
+++ b/eventbusk/brokers/base.py
@@ -24,8 +24,8 @@ __all__ = [
 
 # Type hints
 # callback method `on_delivery` on the producer
-DeliveryCallBackT = Callable[..., None]
-MessageT = str | bytes | cimpl.Message  # pylint: disable=invalid-name
+type DeliveryCallback = Callable[..., None]
+type Message = str | bytes | cimpl.Message
 
 
 class BaseBrokerURI(ABC):
@@ -68,7 +68,7 @@ class BaseConsumer(ContextDecorator, ABC):
         pass
 
     @abstractmethod
-    def poll(self, timeout: int) -> MessageT | None:  # type: ignore
+    def poll(self, timeout: int) -> Message | None:  # type: ignore
         """Poll for a specified time in seconds for new messages."""
 
     @abstractmethod
@@ -90,10 +90,10 @@ class BaseProducer(ABC):
     def produce(  # type: ignore
         self,
         topic: str,
-        value: MessageT,
+        value: Message,
         *,
         flush: bool = True,
-        on_delivery: DeliveryCallBackT = None,
+        on_delivery: DeliveryCallback = None,
         fail_silently: bool = False,
     ) -> None:
         """Send a message on the specific topic.

--- a/eventbusk/brokers/dummy.py
+++ b/eventbusk/brokers/dummy.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 from .base import BaseBrokerURI, BaseConsumer, BaseProducer
 
 if TYPE_CHECKING:
-    from .base import DeliveryCallBackT, MessageT
+    from .base import DeliveryCallback, Message
 
 logger = logging.getLogger(__name__)
 
@@ -64,11 +64,11 @@ class Consumer(BaseConsumer):
         self.topic = topic
         self.group = group
 
-    def poll(self, timeout: int = 1) -> MessageT | None:
+    def poll(self, timeout: int = 1) -> Message | None:
         """Sleeps for the required timeout, and returns no message."""
         time.sleep(timeout)
 
-    def ack(self, message: MessageT) -> None:
+    def ack(self, message: Message) -> None:
         """Acknowledge event."""
 
 
@@ -82,10 +82,10 @@ class Producer(BaseProducer):
     def produce(
         self,
         topic: str,
-        value: MessageT,
+        value: Message,
         *,
         flush: bool = True,
-        on_delivery: DeliveryCallBackT = None,
+        on_delivery: DeliveryCallback = None,
         fail_silently: bool = False,
     ) -> None:
         """Only logs the message, does not deliver."""

--- a/eventbusk/brokers/kafka.py
+++ b/eventbusk/brokers/kafka.py
@@ -18,7 +18,7 @@ from .base import BaseBrokerURI, BaseConsumer, BaseProducer
 if TYPE_CHECKING:
     from types import TracebackType
 
-    from .base import DeliveryCallBackT, MessageT
+    from .base import DeliveryCallback, Message
 
 
 logger = logging.getLogger(__name__)
@@ -30,7 +30,7 @@ __all__ = [
     "Producer",
 ]
 
-ConfigT = dict[str, bool | int | str]
+type Config = dict[str, bool | int | str]
 
 
 @dataclass
@@ -99,9 +99,9 @@ class BrokerURI(BaseBrokerURI):
         )
 
     @property
-    def default_config(self) -> ConfigT:
+    def default_config(self) -> Config:
         """Default configuration for consumer or producer instances."""
-        props: ConfigT = {
+        props: Config = {
             "bootstrap.servers": f"{self.host}:{self.port}",
         }
         if self.sasl:
@@ -177,11 +177,11 @@ class Consumer(BaseConsumer):
                 },
             )
 
-    def poll(self, timeout: int) -> MessageT | None:
+    def poll(self, timeout: int) -> Message | None:
         """Poll the topic for new messages."""
         return self._consumer.poll(timeout)
 
-    def ack(self, message: MessageT | None) -> None:
+    def ack(self, message: Message | None) -> None:
         """Acknowledge the message by explicitly committing."""
         self._consumer.commit(message=message)
 
@@ -198,10 +198,10 @@ class Producer(BaseProducer):
     def produce(
         self,
         topic: str,
-        value: MessageT,
+        value: Message,
         *,
         flush: bool = True,
-        on_delivery: DeliveryCallBackT = None,
+        on_delivery: DeliveryCallback = None,
         fail_silently: bool = False,
     ) -> None:
         """Sends the message to a Kafka topic."""

--- a/eventbusk/bus.py
+++ b/eventbusk/bus.py
@@ -44,8 +44,8 @@ class EventJsonEncoder(json.JSONEncoder):
 
 type EventType = type[Event]
 type Receiver = Callable[[Event], None]
-type WrappedReceiver = Callable[[], None]
-type ReceiverWrapper = Callable[[Receiver], WrappedReceiver]
+type ReceiverWorker = Callable[[], None]
+type ReceiverDecorator = Callable[[Receiver], ReceiverWorker]
 type Hook = Callable[[], None]
 type Hooks = list[Hook] | None
 
@@ -107,7 +107,7 @@ class EventBus:
         # the event class.
         self._topic_to_event: dict[str, str] = {}
         self._event_to_topic: dict[str, str] = {}
-        self._receivers: set[WrappedReceiver] = set()
+        self._receivers: set[ReceiverWorker] = set()
 
     @staticmethod
     def to_fqn(event_type: EventType | Receiver) -> str:
@@ -170,7 +170,7 @@ class EventBus:
                 raise
 
     @property
-    def receivers(self) -> set[WrappedReceiver]:
+    def receivers(self) -> set[ReceiverWorker]:
         """Returns a set of receivers(consumers) of events."""
         return self._receivers
 
@@ -179,7 +179,7 @@ class EventBus:
         self,
         event_type: EventType,
         poll_timeout: int = 1,
-    ) -> ReceiverWrapper:
+    ) -> ReceiverDecorator:
         """Decorator to convert a function into an receiver.
 
         An receiver is a simple function that consumes a specific event on the event
@@ -192,7 +192,7 @@ class EventBus:
                 f"`bus.register_event('foo_topic', {event_type})`",
             )
 
-        def _outer(func: Receiver) -> WrappedReceiver:
+        def _outer(func: Receiver) -> ReceiverWorker:
             # TODO: Ensure group name does not clash
             group = self.to_fqn(func)
             receiver_fqn = self.to_fqn(func)

--- a/eventbusk/bus.py
+++ b/eventbusk/bus.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from functools import wraps
 
-from .brokers import Consumer, DeliveryCallBackT, Producer
+from .brokers import Consumer, DeliveryCallback, Producer
 from .exceptions import AlreadyRegistered, ConsumerError, ProducerError, UnknownEvent
 
 logger = logging.getLogger(__name__)
@@ -42,12 +42,12 @@ class EventJsonEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)
 
 
-EventT = type[Event]
-ReceiverT = Callable[[Event], None]
-ReceiverWrappedT = Callable[[], None]
-ReceivedOuterT = Callable[[ReceiverT], ReceiverWrappedT]
-HookT = Callable[[], None]
-HooksT = list[HookT] | None  # pylint: disable=invalid-name
+type EventType = type[Event]
+type Receiver = Callable[[Event], None]
+type WrappedReceiver = Callable[[], None]
+type ReceiverWrapper = Callable[[Receiver], WrappedReceiver]
+type Hook = Callable[[], None]
+type Hooks = list[Hook] | None
 
 
 class EventBus:
@@ -78,7 +78,7 @@ class EventBus:
     """
 
     @staticmethod
-    def _to_hook_list(hooks: HooksT) -> list[HookT]:
+    def _to_hook_list(hooks: Hooks) -> list[Hook]:
         if hooks is None:
             return []
         return list(hooks)
@@ -87,12 +87,12 @@ class EventBus:
         self,
         broker: str,
         *,
-        before_receive: HooksT = None,
-        after_receive: HooksT = None,
+        before_receive: Hooks = None,
+        after_receive: Hooks = None,
     ) -> None:
         self.broker = broker
-        self._before_receive_hooks: list[HookT] = self._to_hook_list(before_receive)
-        self._after_receive_hooks: list[HookT] = self._to_hook_list(after_receive)
+        self._before_receive_hooks: list[Hook] = self._to_hook_list(before_receive)
+        self._after_receive_hooks: list[Hook] = self._to_hook_list(after_receive)
         # Lazily create on first send
         # This is done to avoid issues forking, causing flush to fail.
         # https://github.com/confluentinc/confluent-kafka-python/issues/1122
@@ -107,16 +107,16 @@ class EventBus:
         # the event class.
         self._topic_to_event: dict[str, str] = {}
         self._event_to_topic: dict[str, str] = {}
-        self._receivers: set[ReceiverWrappedT] = set()
+        self._receivers: set[WrappedReceiver] = set()
 
     @staticmethod
-    def to_fqn(event_type: EventT | ReceiverT) -> str:
+    def to_fqn(event_type: EventType | Receiver) -> str:
         """Returns 'fully qualified name' of an event class or an receiver, to identify
         them uniquely.
         """
         return f"{event_type.__module__}.{event_type.__qualname__}"
 
-    def register_event(self, topic: str, event_type: EventT) -> None:
+    def register_event(self, topic: str, event_type: EventType) -> None:
         """Register an event to a bus.
 
         Each event is only linked to a single topic.
@@ -135,7 +135,7 @@ class EventBus:
         self,
         event: Event,
         *,
-        on_delivery: DeliveryCallBackT = None,
+        on_delivery: DeliveryCallback = None,
         flush: bool = True,
         fail_silently: bool = False,
     ) -> None:
@@ -170,16 +170,16 @@ class EventBus:
                 raise
 
     @property
-    def receivers(self) -> set[ReceiverWrappedT]:
+    def receivers(self) -> set[WrappedReceiver]:
         """Returns a set of receivers(consumers) of events."""
         return self._receivers
 
     # TODO: add group parameter?
     def receive(  # pylint: disable=too-complex
         self,
-        event_type: EventT,
+        event_type: EventType,
         poll_timeout: int = 1,
-    ) -> ReceivedOuterT:
+    ) -> ReceiverWrapper:
         """Decorator to convert a function into an receiver.
 
         An receiver is a simple function that consumes a specific event on the event
@@ -192,7 +192,7 @@ class EventBus:
                 f"`bus.register_event('foo_topic', {event_type})`",
             )
 
-        def _outer(func: ReceiverT) -> ReceiverWrappedT:
+        def _outer(func: Receiver) -> WrappedReceiver:
             # TODO: Ensure group name does not clash
             group = self.to_fqn(func)
             receiver_fqn = self.to_fqn(func)


### PR DESCRIPTION
## Summary

Addresses review feedback to modernize type alias declarations throughout the codebase.

## Changes

- Replace assignment-based type aliases with the Python 3.12+ `type` keyword (PEP 695)
- Rename all aliases to drop the confusing `T` suffix (reserved by convention for `TypeVar`, not `TypeAlias`):

| Old | New |
|-----|-----|
| `EventT` | `EventType` |
| `ReceiverT` | `Receiver` |
| `ReceiverWrappedT` | `ReceiverWorker` |
| `ReceivedOuterT` | `ReceiverDecorator` |
| `HookT` | `Hook` |
| `HooksT` | `Hooks` |
| `DeliveryCallBackT` | `DeliveryCallback` |
| `MessageT` | `Message` |
| `ConfigT` | `Config` |

- Remove all `# pylint: disable=invalid-name` suppression comments on type aliases — no longer needed with the `type` keyword

## Why

- The `T` suffix is universally understood as a `TypeVar` marker in Python; using it on static aliases is misleading
- The `type` keyword (PEP 695, Python 3.12+) is the idiomatic modern syntax — no `TypeAlias` import needed, lazy evaluation built-in, natively understood by pylint and mypy
- Eliminating pylint suppression comments removes a code smell signal